### PR TITLE
Added link for sprint plan 1 in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Tim Buckers
 **SE TA**: Bastiaan Reijm
 
 
-## Links for documentation
+## Links to documents
 
 Sprint Plan 1: [sprint plan 1] (https://github.com/ClintonCao/Contextproject-TSE/blob/master/documentation/Sprint%20Plans/SprintBacklog1(BlueTurtle).pdf)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Contextproject-TSE &nbsp; [![Build Status](https://travis-ci.org/ClintonCao/Contextproject-TSE.svg?branch=master)](https://travis-ci.org/ClintonCao/Contextproject-TSE)
 This is BlueTurtle's repository for Contextproject (TSE) 2015 - 2016.
 
-Team Members:
+**Team Members**:
 
 Boning Gong
 
@@ -13,4 +13,9 @@ Sunwei Wang
 
 Tim Buckers
 
-SE TA: Bastiaan Reijm
+**SE TA**: Bastiaan Reijm
+
+
+## Links for documentation
+
+Sprint Plan 1: [sprint plan 1] (https://github.com/ClintonCao/Contextproject-TSE/blob/master/documentation/Sprint%20Plans/SprintBacklog1(BlueTurtle).pdf)


### PR DESCRIPTION
I've added the link for the first sprint plan in the README.md. I've also bolded "Team Members" and "SE TA". Please let me know if there are any questions.