### PR TITLE
Analysertesting

### DIFF
--- a/src/main/java/BlueTurtle/TSE/Analyser.java
+++ b/src/main/java/BlueTurtle/TSE/Analyser.java
@@ -37,7 +37,14 @@ public class Analyser {
 			ProcessBuilder pb = new ProcessBuilder(command.getArgs());
 			pb.redirectOutput(Redirect.to(new File(command.getDefaultOutputFilePath())));
 			pb.redirectError(Redirect.INHERIT);
-			pb.start();
+			Process process = pb.start();
+			try {
+				process.waitFor();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			process.getOutputStream().flush();
+			process.destroy();
 		}
 	}
 

--- a/src/main/java/BlueTurtle/TSE/Main.java
+++ b/src/main/java/BlueTurtle/TSE/Main.java
@@ -26,7 +26,7 @@ public class Main {
 	static mode currentMode = mode.JAVA;
 
 	/**
-	 * Maind method.
+	 * Main method.
 	 * 
 	 * @param args
 	 *            the arguments.

--- a/src/main/java/BlueTurtle/commandbuilders/CommandBuilder.java
+++ b/src/main/java/BlueTurtle/commandbuilders/CommandBuilder.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
  * @author BlueTurtle.
  *
  */
+@SuppressWarnings("checkstyle:visibilitymodifier")
 public abstract class CommandBuilder {
 	protected ArrayList<String> commands;
 	private Settings settings;

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -1,28 +1,29 @@
 package BlueTurtle.TSE;
 
 import static org.junit.Assert.assertTrue;
-
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import BlueTurtle.commandbuilders.CheckStyleCommandBuilder;
+import BlueTurtle.commandbuilders.CoberturaCommandBuilder;
 import BlueTurtle.commandbuilders.CommandBuilder;
 import BlueTurtle.commandbuilders.PMDCommandBuilder;
+import BlueTurtle.parsers.CheckStyleXMLParser;
+import BlueTurtle.parsers.XMLParser;
 import BlueTurtle.settings.CheckStyleSettings;
+import BlueTurtle.settings.CoberturaSettings;
 import BlueTurtle.settings.PMDSettings;
+import BlueTurtle.warnings.Warning;
 
 /**
  * Unit test for simple Analyser.
  */
 public class AnalyserTest {
-	ArrayList<AnalyserCommand> commands = new ArrayList<AnalyserCommand>();
 
 	@Before
 	/**
@@ -30,20 +31,24 @@ public class AnalyserTest {
 	 * @throws IOException
 	 */
 	public void initialize() throws IOException {
+		ArrayList<AnalyserCommand> commands = new ArrayList<AnalyserCommand>();
 		CommandBuilder commandBuilder;
 		PMDSettings pmdSettings = new PMDSettings();
+		CheckStyleSettings checkStyleSettings = new CheckStyleSettings(new File("CheckStyle_Settings.xml"));
+		
 		commandBuilder = new PMDCommandBuilder(pmdSettings);
 		String[] pmdCommands = commandBuilder.buildCommand();
 		AnalyserCommand c1 = new AnalyserCommand(pmdSettings.getDefaultOutputFilePath(), pmdCommands);
 		commands.add(c1);
 
-		CheckStyleSettings checkStyleSettings = new CheckStyleSettings(new File("CheckStyle_Settings.xml"));
 		commandBuilder = new CheckStyleCommandBuilder(checkStyleSettings);
 		String[] checkStyleCommands = commandBuilder.buildCommand();
 		AnalyserCommand c2 = new AnalyserCommand(checkStyleSettings.getDefaultOutputFilePath(), checkStyleCommands);
 		commands.add(c2);
 
-		
+		Analyser analyser = new Analyser(commands);
+
+		analyser.analyse();
 	}
 
 	/**
@@ -52,10 +57,9 @@ public class AnalyserTest {
 	 */
 	@Test
 	public void testCheckStyleOutput() throws IOException {
-		Analyser analyser = new Analyser(commands);
-		analyser.analyse();
-		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/checkstyle.xml"));
-		assert(br.readLine() != null);
+
+		File file = new File(JavaController.getUserDir() + "/Runnables/Testcode/checkstyle.xml");
+		assertTrue(file.length() > 0);
 	}
 	
 	/**
@@ -64,9 +68,7 @@ public class AnalyserTest {
 	 */
 	@Test
 	public void testPMDOutput() throws IOException {
-		Analyser analyser = new Analyser(commands);
-		analyser.analyse();
-		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/PMD.xml"));
-		assert(br.readLine() != null);
+		File file = new File(JavaController.getUserDir() + "/Runnables/Testcode/PMD.xml");
+		assertTrue(file.length() > 0);
 	}
 }

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -4,21 +4,14 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import BlueTurtle.commandbuilders.CheckStyleCommandBuilder;
-import BlueTurtle.commandbuilders.CoberturaCommandBuilder;
 import BlueTurtle.commandbuilders.CommandBuilder;
 import BlueTurtle.commandbuilders.PMDCommandBuilder;
-import BlueTurtle.parsers.CheckStyleXMLParser;
-import BlueTurtle.parsers.XMLParser;
 import BlueTurtle.settings.CheckStyleSettings;
-import BlueTurtle.settings.CoberturaSettings;
 import BlueTurtle.settings.PMDSettings;
-import BlueTurtle.warnings.Warning;
 
 /**
  * Unit test for simple Analyser.

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -3,12 +3,21 @@ package BlueTurtle.TSE;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import BlueTurtle.commandbuilders.CheckStyleCommandBuilder;
+import BlueTurtle.commandbuilders.CoberturaCommandBuilder;
+import BlueTurtle.commandbuilders.CommandBuilder;
+import BlueTurtle.commandbuilders.PMDCommandBuilder;
+import BlueTurtle.settings.CheckStyleSettings;
+import BlueTurtle.settings.PMDSettings;
 
 /**
  * Unit test for simple Analyser.
@@ -16,9 +25,28 @@ import org.junit.Test;
 public class AnalyserTest {
 	
 	@Before
+	/**
+	 * Set up a command to run PMD and run CheckStyle. These commands are handed to the analyser which runs them.
+	 * @throws IOException
+	 */
 	public void initialize() throws IOException {
-		JavaController javacontroller = new JavaController();
-		javacontroller.execute();
+		ArrayList<AnalyserCommand> commands = new ArrayList<AnalyserCommand>();
+		CommandBuilder commandBuilder;
+		PMDSettings pmdSettings = new PMDSettings();
+		commandBuilder = new PMDCommandBuilder(pmdSettings);
+		String[] pmdCommands = commandBuilder.buildCommand();
+		AnalyserCommand c1 = new AnalyserCommand(pmdSettings.getDefaultOutputFilePath(), pmdCommands);
+		commands.add(c1);
+
+		CheckStyleSettings checkStyleSettings = new CheckStyleSettings(new File("CheckStyle_Settings.xml"));
+		commandBuilder = new CheckStyleCommandBuilder(checkStyleSettings);
+		String[] checkStyleCommands = commandBuilder.buildCommand();
+		AnalyserCommand c2 = new AnalyserCommand(checkStyleSettings.getDefaultOutputFilePath(), checkStyleCommands);
+		commands.add(c2);
+
+		Analyser analyser = new Analyser(commands);
+
+		analyser.analyse();
 	}
 
 	/**

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -3,15 +3,23 @@ package BlueTurtle.TSE;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Unit test for simple Analyser.
  */
 public class AnalyserTest {
+	
+	@Before
+	public void initialize() throws IOException {
+		JavaController javacontroller = new JavaController();
+		javacontroller.execute();
+	}
 
 	/**
 	 * Simple test to check if running the analyser actually produces output for checkstyle.
@@ -19,8 +27,6 @@ public class AnalyserTest {
 	 */
 	@Test
 	public void testCheckStyleOutput() throws IOException {
-		JavaController javacontroller = new JavaController();
-		javacontroller.execute();
 		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/checkstyle.xml"));
 		assert(br.readLine() != null);
 	}
@@ -31,8 +37,6 @@ public class AnalyserTest {
 	 */
 	@Test
 	public void testPMDOutput() throws IOException {
-		JavaController javacontroller = new JavaController();
-		javacontroller.execute();
 		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/pmd.xml"));
 		assert(br.readLine() != null);
 	}

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -18,10 +18,13 @@ import BlueTurtle.settings.PMDSettings;
  */
 public class AnalyserTest {
 
-	
 	/**
-	 * Set up a command to run PMD and run CheckStyle. These commands are handed to the analyser which runs them.
+	 * Set up a command to run PMD and run CheckStyle. These commands are handed
+	 * to the analyser which runs them.
+	 * 
 	 * @throws IOException
+	 *             throws an exception if problem is encounter while building
+	 *             and analysing the commands.
 	 */
 	@Before
 	public void setUp() throws IOException {
@@ -29,7 +32,7 @@ public class AnalyserTest {
 		CommandBuilder commandBuilder;
 		PMDSettings pmdSettings = new PMDSettings();
 		CheckStyleSettings checkStyleSettings = new CheckStyleSettings(new File("CheckStyle_Settings.xml"));
-		
+
 		commandBuilder = new PMDCommandBuilder(pmdSettings);
 		String[] pmdCommands = commandBuilder.buildCommand();
 		AnalyserCommand c1 = new AnalyserCommand(pmdSettings.getDefaultOutputFilePath(), pmdCommands);
@@ -46,18 +49,26 @@ public class AnalyserTest {
 	}
 
 	/**
-	 * Simple test to check if running the analyser actually produces output for checkstyle.
-	 * @throws IOException 
+	 * Simple test to check if running the analyser actually produces output for
+	 * checkstyle.
+	 * 
+	 * @throws IOException
+	 *             throws an exception if problem is encountered while reading
+	 *             the file.
 	 */
 	@Test
 	public void testCheckStyleOutput() throws IOException {
 		File file = new File(JavaController.getUserDir() + "/Runnables/Testcode/checkstyle.xml");
 		assertTrue(file.length() > 0);
 	}
-	
+
 	/**
-	 * Simple test to check if running the analyser actually produces output for PMD.
-	 * @throws IOException 
+	 * Simple test to check if running the analyser actually produces output for
+	 * PMD.
+	 * 
+	 * @throws IOException
+	 *             throws an exception if problem is encountered while reading
+	 *             the file.
 	 */
 	@Test
 	public void testPMDOutput() throws IOException {

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 public class AnalyserTest {
 
 	/**
+	 * Simple test to check if running the analyser actually produces output for checkstyle.
 	 * @throws IOException 
 	 */
 	@Test
@@ -24,5 +25,15 @@ public class AnalyserTest {
 		assert(br.readLine() != null);
 	}
 	
-
+	/**
+	 * Simple test to check if running the analyser actually produces output for PMD.
+	 * @throws IOException 
+	 */
+	@Test
+	public void testPMDOutput() throws IOException {
+		JavaController javacontroller = new JavaController();
+		javacontroller.execute();
+		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/pmd.xml"));
+		assert(br.readLine() != null);
+	}
 }

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -1,0 +1,28 @@
+package BlueTurtle.TSE;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple Analyser.
+ */
+public class AnalyserTest {
+
+	/**
+	 * @throws IOException 
+	 */
+	@Test
+	public void testCheckStyleOutput() throws IOException {
+		JavaController javacontroller = new JavaController();
+		javacontroller.execute();
+		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/checkstyle.xml"));
+		assert(br.readLine() != null);
+	}
+	
+
+}

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -13,7 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import BlueTurtle.commandbuilders.CheckStyleCommandBuilder;
-import BlueTurtle.commandbuilders.CoberturaCommandBuilder;
 import BlueTurtle.commandbuilders.CommandBuilder;
 import BlueTurtle.commandbuilders.PMDCommandBuilder;
 import BlueTurtle.settings.CheckStyleSettings;
@@ -23,14 +22,14 @@ import BlueTurtle.settings.PMDSettings;
  * Unit test for simple Analyser.
  */
 public class AnalyserTest {
-	
+	ArrayList<AnalyserCommand> commands = new ArrayList<AnalyserCommand>();
+
 	@Before
 	/**
 	 * Set up a command to run PMD and run CheckStyle. These commands are handed to the analyser which runs them.
 	 * @throws IOException
 	 */
 	public void initialize() throws IOException {
-		ArrayList<AnalyserCommand> commands = new ArrayList<AnalyserCommand>();
 		CommandBuilder commandBuilder;
 		PMDSettings pmdSettings = new PMDSettings();
 		commandBuilder = new PMDCommandBuilder(pmdSettings);
@@ -44,9 +43,7 @@ public class AnalyserTest {
 		AnalyserCommand c2 = new AnalyserCommand(checkStyleSettings.getDefaultOutputFilePath(), checkStyleCommands);
 		commands.add(c2);
 
-		Analyser analyser = new Analyser(commands);
-
-		analyser.analyse();
+		
 	}
 
 	/**
@@ -55,6 +52,8 @@ public class AnalyserTest {
 	 */
 	@Test
 	public void testCheckStyleOutput() throws IOException {
+		Analyser analyser = new Analyser(commands);
+		analyser.analyse();
 		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/checkstyle.xml"));
 		assert(br.readLine() != null);
 	}
@@ -65,6 +64,8 @@ public class AnalyserTest {
 	 */
 	@Test
 	public void testPMDOutput() throws IOException {
+		Analyser analyser = new Analyser(commands);
+		analyser.analyse();
 		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/PMD.xml"));
 		assert(br.readLine() != null);
 	}

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -65,7 +65,7 @@ public class AnalyserTest {
 	 */
 	@Test
 	public void testPMDOutput() throws IOException {
-		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/pmd.xml"));
+		BufferedReader br = new BufferedReader(new FileReader(JavaController.getUserDir() + "/Runnables/Testcode/PMD.xml"));
 		assert(br.readLine() != null);
 	}
 }

--- a/src/test/java/BlueTurtle/TSE/AnalyserTest.java
+++ b/src/test/java/BlueTurtle/TSE/AnalyserTest.java
@@ -25,12 +25,13 @@ import BlueTurtle.warnings.Warning;
  */
 public class AnalyserTest {
 
-	@Before
+	
 	/**
 	 * Set up a command to run PMD and run CheckStyle. These commands are handed to the analyser which runs them.
 	 * @throws IOException
 	 */
-	public void initialize() throws IOException {
+	@Before
+	public void setUp() throws IOException {
 		ArrayList<AnalyserCommand> commands = new ArrayList<AnalyserCommand>();
 		CommandBuilder commandBuilder;
 		PMDSettings pmdSettings = new PMDSettings();
@@ -57,7 +58,6 @@ public class AnalyserTest {
 	 */
 	@Test
 	public void testCheckStyleOutput() throws IOException {
-
 		File file = new File(JavaController.getUserDir() + "/Runnables/Testcode/checkstyle.xml");
 		assertTrue(file.length() > 0);
 	}


### PR DESCRIPTION
The reason the tests kept failing even though they were correct was because of a major bug in the code. The analyser started processes but did not wait for them to end. This means the Tests ended up checking the files before the processes were actually done and output was written to them. Having completed operating systems this bug brings much shame to me and my family. 