### PR TITLE
Fixed mistake on previous PR for tool output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 sudo: false
 
 script:
-  - mvn site
+  - mvn test
 notifications:
   webhooks:
     - http://octopull.rmhartog.me/api/travis/webhook
@@ -19,6 +19,7 @@ matrix:
   allow_failures:
     - env: BUILD_PR_BRANCH=true
 after_script:
+  - mvn site
   - echo "== CHECKSTYLE_RESULT =="; cat "target/checkstyle-result.xml"; echo "== END_CHECKSTYLE_RESULT =="
   - echo "== PMD_RESULT =="; cat "target/pmd.xml"; echo "== END_PMD_RESULT =="
   - echo "== FINDBUGS_RESULT =="; cat "target/findbugsXml.xml"; echo "== END_FINDBUGS_RESULT =="


### PR DESCRIPTION
I've made a mistake on which order to run the commands on travis. `mvn clean test jacoco:report coveralls:report` causes the reports to be removed. 

Sorry, my bad :stuck_out_tongue: 