### PR TITLE
Fix slash problem in linux and windows

### DIFF
--- a/src/main/java/BlueTurtle/parsers/FindBugsXMLParser.java
+++ b/src/main/java/BlueTurtle/parsers/FindBugsXMLParser.java
@@ -50,7 +50,7 @@ public class FindBugsXMLParser extends XMLParser {
 			// Normalize the elements of the document.
 			doc.getDocumentElement().normalize();
 			
-			// Get the list of file pathes of the project.
+			// Get the list of file path of the project.
 			NodeList pathsList = doc.getElementsByTagName("Project");
 			
 			NodeList srcList = doc.getElementsByTagName("SrcDir");
@@ -75,31 +75,23 @@ public class FindBugsXMLParser extends XMLParser {
 					// Get the class name where the warning is from.
 					String className = fileElement.getAttribute("classname");
 					
-					// replace the . with \\ in the file name.
-					className = className.replaceAll("\\.", "\\\\");
+					// split the class name into a string array.
+					String [] classArray = className.split("\\.");
 					
-					// initially start with 0
-					int k = 0;
-					// With an empty file path
-					String filePath = "";
+					// the last one is the class name.
+					className = classArray[classArray.length-1];
 					
-					// continue go down the list of source path if the file does not exist.
-//					do {
-//						// get the source path from the node.
-//						pathFront = srcList.item(k).getTextContent(); 
-						
-						// concatenate the source path with the class name.
-						filePath = pathFront + "\\" + className + ".java";
-						
-//						// increment the counter
-//						k++;
-//						// check if the file exits or not.
-//					} while(!new File(filePath).exists());
+					// concatenate the source path with the class name.
+					String fileN = className + ".java";
 					
+					fileN = fileN.substring(fileN.lastIndexOf(File.separatorChar)+1, fileN.length());
+
+					// get the file path from the file name.
+					String filePath = new File(fileN).getCanonicalPath();
 
 					// Get the name of the file where the warning is from.
-					String fileName = Paths.get(filePath).getFileName().toString();
-
+					String fileName = filePath.substring(filePath.lastIndexOf(File.separatorChar) + 1, filePath.length());
+					
 					// Get all the warnings.
 					NodeList warningList = fileElement.getElementsByTagName("BugInstance");
 

--- a/src/main/java/BlueTurtle/warnings/FindBugsWarning.java
+++ b/src/main/java/BlueTurtle/warnings/FindBugsWarning.java
@@ -30,7 +30,7 @@ public class FindBugsWarning extends Warning {
 	 *            the priority of the warning.            
 	 * @param ruleName
 	 *            the rule name of the warning.
-	 * @param Classification
+	 * @param classification
 	 *            of the violated rule of the warning.
 	 */
 	public FindBugsWarning(String filePath, String filename, int line, String message, String category, String priority, String ruleName, String classification) {

--- a/src/test/java/BlueTurtle/parsers/FindBugsXMLParserTest.java
+++ b/src/test/java/BlueTurtle/parsers/FindBugsXMLParserTest.java
@@ -1,14 +1,17 @@
 package BlueTurtle.parsers;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import BlueTurtle.warnings.FindBugsWarning;
 import BlueTurtle.warnings.Warning;
 
 /**
@@ -23,13 +26,14 @@ public class FindBugsXMLParserTest {
 	private static String testSet2 = "./src/test/resources/exampleFindbugs1.xml";
 	private static String testSet3 = "./src/test/resources/asat-gdc-mapping.html";
 
-	private static String testSet2FilePath = "C:\\Users\\wangs\\Documents\\GitHub\\Contextproject-TSE\\src\\main\\java\\BlueTurtle\\warnings\\FindBugsWarning.java";
+//	private static String testSet2FilePath = "C:\\Users\\wangs\\Documents\\GitHub\\Contextproject-TSE\\src\\main\\java\\BlueTurtle\\warnings\\FindBugsWarning.java";
 	private static String testSet2FileName = "FindBugsWarning.java";
 	private static String testSet2RuleName = "HE_EQUALS_USE_HASHCODE";
 	private static String testSet2Message = "BlueTurtle.warnings.FindBugsWarning defines equals and uses Object.hashCode()";
 	private static String testSet2Category = "BAD_PRACTICE";
 	private static String testSet2Priority = "High";
 	private static String testSet2Classification = "Interface";
+	private static String testSet3FilePath = System.getProperty("user.dir") + File.separatorChar+ "FindBugsWarning.java";
 
 	private static HashMap<String, String> categoryInfo = new HashMap<String,String>();
 
@@ -56,17 +60,29 @@ public class FindBugsXMLParserTest {
 	/**
 	 * Test whether the parser creates the right object.
 	 */
-//	@Test
-//	public void testParsingOneWarning() {
-//		FindBugsXMLParser parser = new FindBugsXMLParser();
-//
-//		FindBugsWarning expected = new FindBugsWarning(testSet2FilePath, testSet2FileName, 47,
-//				testSet2Message, testSet2Category, testSet2Priority, testSet2RuleName);
-//
-//		FindBugsWarning actual = (FindBugsWarning) parser.parseFile(testSet2).get(0);
-//
-//		assertEquals(expected, actual);
-//	}
+	@Test
+	public void testParsingOneWarning() {
+		FindBugsXMLParser parser = new FindBugsXMLParser();
+
+		FindBugsWarning expected = new FindBugsWarning(testSet3FilePath, testSet2FileName, 47,
+				testSet2Message, testSet2Category, testSet2Priority, testSet2RuleName, testSet2Classification);
+
+		FindBugsWarning actual = (FindBugsWarning) parser.parseFile(testSet2,categoryInfo).get(0);
+		
+		System.out.println(expected.getFileName() + " |  | " + actual.getFileName());
+		System.out.println(expected.getCategory() + " |  | " + actual.getCategory());
+		System.out.println(expected.getFilePath()); 
+		System.out.println(actual.getFilePath());
+		System.out.println(expected.getLine() + " |  | " + actual.getLine());
+		System.out.println(expected.getMessage() + " |  | " + actual.getMessage());
+		System.out.println(expected.getPriority() + " |  | " + actual.getPriority());
+		System.out.println(expected.getRuleName() + " |  | " + actual.getRuleName());
+		System.out.println(expected.getType() + " |  | " + actual.getType());
+		System.out.println(expected.getClassification() + " |  | " + actual.getClassification());
+		System.out.println(""+ expected.equals(actual));
+
+		assertEquals(expected, actual);
+	}
 
 	/**
 	 * Test that the parser created the right amount of warnings.

--- a/src/test/java/BlueTurtle/parsers/FindBugsXMLParserTest.java
+++ b/src/test/java/BlueTurtle/parsers/FindBugsXMLParserTest.java
@@ -68,18 +68,6 @@ public class FindBugsXMLParserTest {
 				testSet2Message, testSet2Category, testSet2Priority, testSet2RuleName, testSet2Classification);
 
 		FindBugsWarning actual = (FindBugsWarning) parser.parseFile(testSet2,categoryInfo).get(0);
-		
-		System.out.println(expected.getFileName() + " |  | " + actual.getFileName());
-		System.out.println(expected.getCategory() + " |  | " + actual.getCategory());
-		System.out.println(expected.getFilePath()); 
-		System.out.println(actual.getFilePath());
-		System.out.println(expected.getLine() + " |  | " + actual.getLine());
-		System.out.println(expected.getMessage() + " |  | " + actual.getMessage());
-		System.out.println(expected.getPriority() + " |  | " + actual.getPriority());
-		System.out.println(expected.getRuleName() + " |  | " + actual.getRuleName());
-		System.out.println(expected.getType() + " |  | " + actual.getType());
-		System.out.println(expected.getClassification() + " |  | " + actual.getClassification());
-		System.out.println(""+ expected.equals(actual));
 
 		assertEquals(expected, actual);
 	}


### PR DESCRIPTION
Fix the FindBugs Parser, solve the problem the slash works differently in linux than in windows.