### PR TITLE
Added config file for Better Code Hub to ignore d3 library and example ouput file.

### DIFF
--- a/.scope.yml
+++ b/.scope.yml
@@ -1,0 +1,10 @@
+component_depth: 1
+languages:
+- java
+- javascript
+
+exclude:
+- .*/d3.*
+- .*/SummarizedOuput.*
+- .*/input.*
+  


### PR DESCRIPTION
I've created a config file so that SIG can skip checking the D3 library and also the example output from out system. 