### PR TITLE
Removed hashCode and equals method in superclass

### DIFF
--- a/src/main/java/BlueTurtle/warnings/Warning.java
+++ b/src/main/java/BlueTurtle/warnings/Warning.java
@@ -40,17 +40,4 @@ public abstract class Warning {
 		setClassification(classification); 
 	}
 	
-	/**
-	 * Check whether two warnings are the same exact warning.
-	 * @param other the other warning.
-	 * @return a boolean.
-	 */
-	@Override
-	public abstract boolean equals(Object other);
-	
-	/**
-	 * HashCode for the object.
-	 */
-	@Override
-	public abstract int hashCode();
 }


### PR DESCRIPTION
I removed the two methods in the superclass 'Warning'. This is done based on the feedback of our TA.

Please review and merge.